### PR TITLE
Fixed absent `/css/min/` dir

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ var maxSize = Number.MAX_VALUE,
 var listOfMinimizers = Object.keys(minimizers);
 
 // makes dirs
+utils.mkdir(toMinCSS);
 listOfMinimizers.forEach(function(minimizer) {
     utils.mkdir(path.join(toMinCSS, minimizer));
 });


### PR DESCRIPTION
We need to create a `/css/min/` dir before creating other nested dirs, otherwise we can get this error:

``` sh
kizu at kizu-osx in ~/Projects/css-minimizers-bench on master
$ bin/compare-minimizers

/Users/kizu/Projects/css-minimizers-bench/lib/utils.js:12
        if (err && err.code !== 'EEXIST') throw err;
                                                ^
Error: ENOENT, no such file or directory 'css/min/CSSO'
    at Object.fs.mkdirSync (fs.js:642:18)
    at Object.mkdir (/Users/kizu/Projects/css-minimizers-bench/lib/utils.js:9:12)
    at /Users/kizu/Projects/css-minimizers-bench/lib/index.js:19:11
    at Array.forEach (native)
    at Object.<anonymous> (/Users/kizu/Projects/css-minimizers-bench/lib/index.js:18:18)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```
